### PR TITLE
Include library(markdown) for shinyapps.io deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 *.DS_Store
 *.Rproj
+shinyApp/rsconnect/*

--- a/shinyApp/global.R
+++ b/shinyApp/global.R
@@ -8,6 +8,7 @@ library(plotly) #interactive ploting
 library(forecast) #for forecasting
 library(tsbox) #for forecasting
 library(ggfortify) #for forecasting plot
+library(markdown)
 
 source("www/functions/helper_functions.R")
 


### PR DESCRIPTION
Need to include this library for shinyapps.io deployment as discussed below

https://community.rstudio.com/t/warning-error-in-loadnamespace-there-is-no-package-called-markdown/121671